### PR TITLE
Fix Step model inputs default

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 
 class StepInput(BaseModel):
@@ -9,7 +9,7 @@ class StepInput(BaseModel):
 class Step(BaseModel):
     id: str
     description: str
-    inputs: List[StepInput] = []
+    inputs: List[StepInput] = Field(default_factory=list)
 
 class StepResponse(BaseModel):
     step_id: str


### PR DESCRIPTION
## Summary
- ensure Step `inputs` uses `Field(default_factory=list)`
- import Field from pydantic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68838e4b264c832499069ffa5f07d9ca