### PR TITLE
Update README on response storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 
 3. **Store User Inputs:**
 
-   * For each step completed, capture the user's inputs and store them in a structured file, such as a JSON or CSV file.
+   * For each step completed, capture the user's inputs.
+   * Responses are stored in JSON format in `responses.json`.
+   * To store data in CSV, replace the JSON storage backend with a CSV implementation.
    * Each entry should contain:
 
      * The step ID.


### PR DESCRIPTION
## Summary
- clarify how user inputs are stored
- mention how to switch to CSV format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -q -r requirements.txt` *(fails: could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_688398f4429083248b5054496f2924f3