### PR TITLE
Update gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+
+__pycache__/
+.pytest_cache/
+responses.json


### PR DESCRIPTION
## Summary
- ignore Python cache directories
- ignore pytest cache directory
- ignore generated responses.json file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688398f2f9b483249241459e2b8d5bc9