### PR TITLE
Handle id element in loader

### DIFF
--- a/app/sop_loader.py
+++ b/app/sop_loader.py
@@ -8,7 +8,11 @@ def load_sop(xml_path: Path) -> List[Step]:
     root = tree.getroot()
     steps = []
     for step_el in root.findall("step"):
-        step_id = step_el.get("id") or str(len(steps) + 1)
+        step_id = step_el.get("id")
+        if step_id is None:
+            step_id = step_el.findtext("id")
+        if not step_id:
+            step_id = str(len(steps) + 1)
         description = step_el.findtext("description", default="")
         inputs_el = step_el.find("inputs")
         inputs = []

--- a/tests/test_sop_loader.py
+++ b/tests/test_sop_loader.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.sop_loader import load_sop
+
+
+def test_load_sop_reads_id_element(tmp_path: Path):
+    xml = tmp_path / "sop.xml"
+    xml.write_text(
+        """
+<sop>
+    <step>
+        <id>1</id>
+        <description>Desc</description>
+    </step>
+</sop>
+"""
+    )
+    steps = load_sop(xml)
+    assert len(steps) == 1
+    assert steps[0].id == "1"
+    assert steps[0].description == "Desc"


### PR DESCRIPTION
## Summary
- parse `<id>` subelement when missing an `id` attribute in the SOP loader
- add regression test for `<id>` element based SOP files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6883e6c167848324a45232b1a1040819